### PR TITLE
Fixes for the StS 2.0 release (watcher update)

### DIFF
--- a/src/main/java/slimebound/actions/AddPreparedAction.java
+++ b/src/main/java/slimebound/actions/AddPreparedAction.java
@@ -24,8 +24,8 @@ public class AddPreparedAction extends AbstractGameAction {
         AbstractCard c;
 
         c = CardLibrary.getCard(Prepare.ID).makeCopy();
-        c.modifyCostForTurn(-9);
-
+        // c.modifyCostForTurn(-9);
+        c.setCostForTurn(c.cost - 9);
 
         if (upgradeCard) {
             c.upgrade();

--- a/src/main/java/slimebound/actions/DividerAction.java
+++ b/src/main/java/slimebound/actions/DividerAction.java
@@ -39,8 +39,8 @@ public class DividerAction extends AbstractGameAction {
         }
 
         if (this.target.currentHealth > 0) {
-            this.target.damageFlash = true;
-            this.target.damageFlashFrames = 4;
+            // this.target.damageFlash = true;
+            // this.target.damageFlashFrames = 4;
             AbstractDungeon.effectList.add(new com.megacrit.cardcrawl.vfx.combat.GhostIgniteEffect(this.target.hb.cX, this.target.hb.cY));
             if (MathUtils.randomBoolean()) {
                 AbstractDungeon.actionManager.addToBottom(new SFXAction("GHOST_ORB_IGNITE_1", 0.3F));

--- a/src/main/java/slimebound/actions/MultiLickAction.java
+++ b/src/main/java/slimebound/actions/MultiLickAction.java
@@ -65,8 +65,8 @@ public class MultiLickAction extends AbstractGameAction {
                 } else {
 
                     if (this.target.currentHealth > 0) {
-                        this.target.damageFlash = true;
-                        this.target.damageFlashFrames = 4;
+                        // this.target.damageFlash = true;
+                        // this.target.damageFlashFrames = 4;
                         AbstractDungeon.effectList.add(new FlashAtkImgEffect(this.target.hb.cX, this.target.hb.cY, this.attackEffect));
                        // this.info.applyPowers(this.info.owner, this.target);
                        // this.target.damage(this.info);

--- a/src/main/java/slimebound/cards/DecasProtection.java
+++ b/src/main/java/slimebound/cards/DecasProtection.java
@@ -47,7 +47,8 @@ public class DecasProtection extends AbstractSlimeboundCard {
         if (upgraded) AbstractDungeon.actionManager.addToBottom(new ApplyPowerAction(p, p, new ArtifactPower(p, 1), 1));
 
         AbstractCard c = AbstractDungeon.returnTrulyRandomCardInCombat(CardType.POWER).makeCopy();
-        c.modifyCostForTurn(this.magicNumber * -1);
+        // c.modifyCostForTurn(this.magicNumber * -1);
+        c.setCostForTurn(c.cost + (this.magicNumber * -1));
         AbstractDungeon.actionManager.addToBottom(new com.megacrit.cardcrawl.actions.common.MakeTempCardInHandAction(c, true));
 
 

--- a/src/main/java/slimebound/cards/DonusPower.java
+++ b/src/main/java/slimebound/cards/DonusPower.java
@@ -46,7 +46,8 @@ public class DonusPower extends AbstractSlimeboundCard {
       if (upgraded) AbstractDungeon.actionManager.addToBottom(new ApplyPowerAction(p, p, new ArtifactPower(p, 1), 1));
 
         AbstractCard c = AbstractDungeon.returnTrulyRandomCardInCombat(CardType.ATTACK).makeCopy();
-        c.modifyCostForTurn(this.magicNumber * -1);
+        // c.modifyCostForTurn(this.magicNumber * -1);
+        c.setCostForTurn(c.cost + (this.magicNumber * -1));
         AbstractDungeon.actionManager.addToBottom(new com.megacrit.cardcrawl.actions.common.MakeTempCardInHandAction(c, true));
 
 

--- a/src/main/java/slimebound/vfx/GoopCardFlash.java
+++ b/src/main/java/slimebound/vfx/GoopCardFlash.java
@@ -33,17 +33,17 @@ public class GoopCardFlash extends AbstractGameEffect {
         this.isSuper = isSuper;
         this.duration = 0.5F;
         if (isSuper) {
-            this.img = ImageMaster.CARD_FLASH_VFX;
+            this.img = ImageMaster.CARD_FLASH_VFX.getTexture();
         } else {
             switch(card.type) {
                 case POWER:
-                    this.img = ImageMaster.CARD_POWER_BG_SILHOUETTE;
+                    this.img = ImageMaster.CARD_POWER_BG_SILHOUETTE.getTexture();
                     break;
                 case ATTACK:
-                    this.img = ImageMaster.CARD_ATTACK_BG_SILHOUETTE;
+                    this.img = ImageMaster.CARD_ATTACK_BG_SILHOUETTE.getTexture();
                     break;
                 default:
-                    this.img = ImageMaster.CARD_SKILL_BG_SILHOUETTE;
+                    this.img = ImageMaster.CARD_SKILL_BG_SILHOUETTE.getTexture();
             }
         }
 
@@ -61,13 +61,13 @@ public class GoopCardFlash extends AbstractGameEffect {
         this.duration = 0.5F;
         switch(card.type) {
             case POWER:
-                this.img = ImageMaster.CARD_POWER_BG_SILHOUETTE;
+                this.img = ImageMaster.CARD_POWER_BG_SILHOUETTE.getTexture();
                 break;
             case ATTACK:
-                this.img = ImageMaster.CARD_ATTACK_BG_SILHOUETTE;
+                this.img = ImageMaster.CARD_ATTACK_BG_SILHOUETTE.getTexture();
                 break;
             default:
-                this.img = ImageMaster.CARD_SKILL_BG_SILHOUETTE;
+                this.img = ImageMaster.CARD_SKILL_BG_SILHOUETTE.getTexture();
         }
 
         this.color = c;


### PR DESCRIPTION
Summary of changes:

damageFlash and damageFlashFrames are no longer available as properties in AbstractGameEffect.  It appears that they may not be needed, but I've simply commented them out rather than removing them just in case.  This affects DividerAction and MultiLickAction.

modifyCostForTurn() is no longer available in AbstractCard, so you have to use setCostForTurn() instead now.  This affects AddPreparedAction, DecasProtection, and DonusPower.  I updated the math to account for using set instead of modify, but you might want to just change the costs to be static if that's appropriate.

ImageMaster.TextureAtlas no longer provides an overload for =(Texture)TextureAtlas, so you have to call getTexture() explicitly now.  This affects GoopCardFlash.

I did play through Act 1 on SlimeBound after making the above changes, along with merging the currently-open PRs, and everything seemed to work, but this was my first time playing SlimeBound, so I don't know for sure if I missed anything.

--Arek75
