### PR TITLE
Fix for orb slot graphics and missing channel sfx

### DIFF
--- a/src/main/java/slimebound/cards/PrepareCrush.java
+++ b/src/main/java/slimebound/cards/PrepareCrush.java
@@ -42,6 +42,7 @@ public class PrepareCrush extends AbstractSlimeboundCard {
         this.exhaust = true;
         this.magicNumber = this.baseMagicNumber = 3;
         this.exhaust = true;
+        this.cardsToPreview = new SlimeCrush();
     }
 
     public void use(AbstractPlayer p, AbstractMonster m) {

--- a/src/main/java/slimebound/orbs/SpawnedSlime.java
+++ b/src/main/java/slimebound/orbs/SpawnedSlime.java
@@ -295,7 +295,7 @@ public void spawnVFX(){
 
     public void playChannelSFX() {
 
-        CardCrawlGame.sound.play("SLIMED_ATK", 0.1F);
+        CardCrawlGame.sound.play("MONSTER_SLIME_ATTACK", 0.1F);
 
     }
 

--- a/src/main/java/slimebound/patches/EmptyOrbSlotGraphicsPatch.java
+++ b/src/main/java/slimebound/patches/EmptyOrbSlotGraphicsPatch.java
@@ -24,8 +24,8 @@ import java.util.ArrayList;
 @SpirePatch(clz= EmptyOrbSlot.class,method="updateDescription"
    )
 public class EmptyOrbSlotGraphicsPatch {
-	static Texture NORMAL_ORB = ImageMaster.ORB_SLOT_1;
-	static Texture SLIME_ORB = ImageMaster.loadImage("SlimeboundImages/orbs/empty1.png");
+	public static Texture NORMAL_ORB = ImageMaster.ORB_SLOT_1;
+	public static Texture SLIME_ORB = ImageMaster.loadImage("SlimeboundImages/orbs/empty1.png");
     public static void Postfix(EmptyOrbSlot EmptyOrbSlot_instance) {
         if (AbstractDungeon.player instanceof SlimeboundCharacter) {
             ImageMaster.ORB_SLOT_1 = SLIME_ORB;

--- a/src/main/java/slimebound/patches/EmptyOrbSlotGraphicsPatch.java
+++ b/src/main/java/slimebound/patches/EmptyOrbSlotGraphicsPatch.java
@@ -24,21 +24,15 @@ import java.util.ArrayList;
 @SpirePatch(clz= EmptyOrbSlot.class,method="updateDescription"
    )
 public class EmptyOrbSlotGraphicsPatch {
-
+	static Texture NORMAL_ORB = ImageMaster.ORB_SLOT_1;
+	static Texture SLIME_ORB = ImageMaster.loadImage("SlimeboundImages/orbs/empty1.png");
     public static void Postfix(EmptyOrbSlot EmptyOrbSlot_instance) {
-
         if (AbstractDungeon.player instanceof SlimeboundCharacter) {
-
-            Texture image = (Texture) ReflectionHacks.getPrivate(EmptyOrbSlot_instance, EmptyOrbSlot.class, "img1");
-            if (image != null){
-                ReflectionHacks.setPrivate(EmptyOrbSlot_instance, EmptyOrbSlot.class, "img1", ImageMaster.loadImage("SlimeboundImages/orbs/empty1.png"));
-
-            }
-
-
+            ImageMaster.ORB_SLOT_1 = SLIME_ORB;
+        } else {
+        	ImageMaster.ORB_SLOT_1 = NORMAL_ORB;
         }
-
     }
-    }
+}
 
 


### PR DESCRIPTION
Empty orb slots now use `ImageMaster.ORB_SLOT_1` for the graphic instead of a private variable, so I changed the existing patch to instead swap out the global texture when an orb slot spawns depending on whether you're the Slimebound or not. It could probably be done much better, but it works for now.

The custom orbs were using `SLIMED_ATK` for a channel SFX, which has been renamed to `MONSTER_SLIME_ATTACK`. Just replaced the name so it would work again.